### PR TITLE
Upgrade sttp to 4

### DIFF
--- a/Toolkit.js.scala
+++ b/Toolkit.js.scala
@@ -1,6 +1,6 @@
 //> using scala "2.13", "2.12", "3"
 
-//> using lib "com.softwaremill.sttp.client3::core::3.8.7"
-//> using lib "com.softwaremill.sttp.client3::upickle::3.8.7"
+//> using lib "com.softwaremill.sttp.client4::core::4.0.0-M1"
+//> using lib "com.softwaremill.sttp.client4::upickle::4.0.0-M1"
 //> using lib "com.lihaoyi::upickle::2.0.0"
 //> using lib "org.scalameta::munit::1.0.0-M7"

--- a/Toolkit.scala
+++ b/Toolkit.scala
@@ -1,7 +1,7 @@
 //> using scala "2.13", "2.12", "3"
 
-//> using lib "com.softwaremill.sttp.client3::core::3.8.7"
-//> using lib "com.softwaremill.sttp.client3::upickle::3.8.7"
+//> using lib "com.softwaremill.sttp.client4::core::4.0.0-M1"
+//> using lib "com.softwaremill.sttp.client4::upickle::4.0.0-M1"
 //> using lib "com.lihaoyi::upickle::2.0.0"
 //> using lib "com.lihaoyi::os-lib::0.9.0"
 //> using lib "org.scalameta::munit::1.0.0-M7"


### PR DESCRIPTION
Sttp 4.0.0-M1 has just been release: https://github.com/softwaremill/sttp/releases/tag/v4.0.0-M1

Since the toolkit is still in experimental phase, I think we can use a milestone version of sttp in it. This will make it easier to write the tutorials using the new sttp API.