### PR TITLE
Update deps and fix publishing

### DIFF
--- a/Toolkit.js.scala
+++ b/Toolkit.js.scala
@@ -2,4 +2,4 @@
 //> using publish.name "toolkit"
 //> using lib "com.softwaremill.sttp.client4::core::4.0.0-M1"
 //> using lib "com.softwaremill.sttp.client4::upickle::4.0.0-M1"
-//> using lib "com.lihaoyi::upickle::3.0.0"
+//> using lib "com.lihaoyi::upickle::3.1.0"

--- a/Toolkit.scala
+++ b/Toolkit.scala
@@ -2,5 +2,5 @@
 //> using publish.name "toolkit"
 //> using lib "com.softwaremill.sttp.client4::core::4.0.0-M1"
 //> using lib "com.softwaremill.sttp.client4::upickle::4.0.0-M1"
-//> using lib "com.lihaoyi::upickle::3.0.0"
+//> using lib "com.lihaoyi::upickle::3.1.0"
 //> using lib "com.lihaoyi::os-lib::0.9.1"

--- a/publish-conf.scala
+++ b/publish-conf.scala
@@ -1,7 +1,7 @@
 //> using publish.organization "org.scala-lang"
 //> using publish.computeVersion "git:tag"
 //> using publish.url "https://github.com/scala/toolkit"
-//> using publish.versionControl "scm:git:github.com/scala/toolkit.git"
+//> using publish.vcs "github:scala/toolkit"
 //> using publish.license "Apache-2.0"
 //> using publish.repository "central"
 //> using publish.developer "szymon-rd|Simon R|https://github.com/szymon-rd"


### PR DESCRIPTION
The publishing of v0.1.7 failed because of:
```
[error] ./publish-conf.scala:4:35
[error] Malformed vcs "scm:git:github.com/scala/toolkit.git", expected url|connection|developer-connection
[error] //> using publish.versionControl "scm:git:github.com/scala/toolkit.git"
[error]                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

This PR should fix it.